### PR TITLE
fix py3.6 f-string ID for !a

### DIFF
--- a/macropy/core/__init__.py
+++ b/macropy/core/__init__.py
@@ -408,7 +408,7 @@ if compat.HAS_FSTRING:
     trec.update({
         ast.FormattedValue: lambda tree, i: ("{" +  rec(tree.value, i) +
                                         {-1: "", 115: "!s", 114: "!r",
-                                         115: "!a"}[tree.conversion] +
+                                         97: "!a"}[tree.conversion] +
                                         ((":" + tree.format_spec.values[0].s)
                                          if tree.format_spec else "") +
                                         "}"),


### PR DESCRIPTION
Something I noticed when reading through the MacroPy source.

There was a duplicate key in the dict; checked the correct value from GTS docs of `FormattedValue`, and fixed it; now `!a` should be supported correctly.