### PR TITLE
Named arguments for macros

### DIFF
--- a/macropy/core/macros.py
+++ b/macropy/core/macros.py
@@ -108,18 +108,16 @@ class MacroType(ABC):
           - the tree containing the macro itself (it is *macro_tree*
             itself as of now);
           - arguments to the macro invocation;
-          - if a Call, named arguments to the macro invocation, as OrderedDict.
+          - named arguments to the macro invocation.
 
         """
-        kwargs = collections.OrderedDict()  # keywords is a list; preserve order
         if isinstance(macro_tree, ast.Call):
             call_args = tuple(macro_tree.args)
-            for kw in macro_tree.keywords:
-                if kw.arg is not None:
-                    kwargs[kw.arg] = kw.value
+            kwargs = tuple(macro_tree.keywords)
             macro_tree = macro_tree.func
         else:
             call_args = ()
+            kwargs = ()
         if isinstance(macro_tree, ast.Name):
             return macro_tree.id, macro_tree, call_args, kwargs
         else:

--- a/macropy/core/macros.py
+++ b/macropy/core/macros.py
@@ -73,7 +73,7 @@ def macro_stub(func):
 
 MacroData = collections.namedtuple('MacroData', ['macro', 'macro_tree',
                                                  'body_tree', 'call_args',
-                                                 'kwargs', 'extrakws', 'name'])
+                                                 'call_kwargs', 'extrakws', 'name'])
 
 MacroData.__doc__ = """
 Contains a macro's detailed informations needed to expand it.
@@ -113,15 +113,15 @@ class MacroType(ABC):
         """
         if isinstance(macro_tree, ast.Call):
             call_args = tuple(macro_tree.args)
-            kwargs = tuple(macro_tree.keywords)
+            call_kwargs = {x.arg: x.value for x in macro_tree.keywords}
             macro_tree = macro_tree.func
         else:
             call_args = ()
-            kwargs = ()
+            call_kwargs = {}
         if isinstance(macro_tree, ast.Name):
-            return macro_tree.id, macro_tree, call_args, kwargs
+            return macro_tree.id, macro_tree, call_args, call_kwargs
         else:
-            return None, macro_tree, call_args, kwargs
+            return None, macro_tree, call_args, call_kwargs
 
     @abstractmethod
     def detect_macro(self, in_tree):
@@ -150,10 +150,10 @@ class Expr(MacroType):
         if (isinstance(in_tree, ast.Subscript) and
             type(in_tree.slice) is ast.Index):  # noqa: E129
             body_tree = in_tree.slice.value
-            name, macro_tree, call_args, kwargs = self.get_macro_details(in_tree.value)
+            name, macro_tree, call_args, call_kwargs = self.get_macro_details(in_tree.value)
             if name is not None and name in self.registry:
                 new_tree = yield MacroData(self.registry[name], macro_tree,
-                                           body_tree, call_args, kwargs, {}, name)
+                                           body_tree, call_args, call_kwargs, {}, name)
                 assert isinstance(new_tree, ast.expr), ('Wrong type %r' %
                                                         type(new_tree))
                 new_tree = ast.Expr(new_tree)
@@ -174,11 +174,11 @@ class Block(MacroType):
             assert isinstance(in_tree.body, list), real_repr(in_tree.body)
             new_tree = None
             for wi in in_tree.items:
-                name, macro_tree, call_args, kwargs = self.get_macro_details(
+                name, macro_tree, call_args, call_kwargs = self.get_macro_details(
                     wi.context_expr)
                 if name is not None and name in self.registry:
                     new_tree = yield MacroData(self.registry[name], macro_tree,
-                                               in_tree.body, call_args, kwargs,
+                                               in_tree.body, call_args, call_kwargs,
                                                {'target': wi.optional_vars}, name)
 
             if new_tree:
@@ -214,7 +214,7 @@ class Decorator(MacroType):
             additions = []
             # process each decorator from the innermost outwards
             for dec in rev_decs:
-                name, macro_tree, call_args, kwargs = self.get_macro_details(dec)
+                name, macro_tree, call_args, call_kwargs = self.get_macro_details(dec)
                 # if the decorator is not a macro, add it to a list
                 # for later re-insertion, either before executing an
                 # outer macro or at the end of the loop if no macro is found
@@ -228,7 +228,7 @@ class Decorator(MacroType):
                                            tree.decorator_list)
                     seen_decs = []
                 tree = yield MacroData(self.registry[name], macro_tree, tree,
-                                       call_args, kwargs, {}, name)
+                                       call_args, call_kwargs, {}, name)
                 if type(tree) is list:
                     additions = tree[1:]
                     tree = tree[0]
@@ -499,7 +499,7 @@ class ExpansionContext:
             new_tree = mfunc(
                 tree=new_tree,
                 args=macro_data.call_args,
-                kwargs=macro_data.kwargs,
+                kwargs=macro_data.call_kwargs,
                 src=self.src,
                 expand_macros=self.expand_macros,
                 **dict(tuple(macro_data.extrakws.items()) +
@@ -530,7 +530,7 @@ class ExpansionContext:
             new_tree = function(
                 tree=new_tree,
                 args=macro_data.call_args,
-                kwargs=macro_data.kwargs,
+                kwargs=macro_data.call_kwargs,
                 src=self.src,
                 expand_macros=self.expand_macros,
                 lineno=macro_data.macro_tree.lineno,

--- a/macropy/core/test/macros/argument.py
+++ b/macropy/core/test/macros/argument.py
@@ -1,8 +1,10 @@
-from macropy.core.test.macros.argument_macros import macros, expr_macro, block_macro, decorator_macro
+from macropy.core.test.macros.argument_macros import macros, expr_macro, block_macro, decorator_macro, expr_macro_with_named_args
 import math
 
 def run():
     x = expr_macro(1 + math.sqrt(5))[10 + 10 + 10]
+
+    x = expr_macro_with_named_args(1 + 2 + 3, a=(1 + math.sqrt(5)))[10 + 10 + 10]
 
     with block_macro(1 + math.sqrt(5)) as y:
         x = x + 1

--- a/macropy/core/test/macros/argument_macros.py
+++ b/macropy/core/test/macros/argument_macros.py
@@ -4,6 +4,13 @@ import macropy.core.macros
 macros = macropy.core.macros.Macros()
 
 @macros.expr
+def expr_macro_with_named_args(tree, args, kwargs, **kw):
+    assert "a" in kwargs, kwargs
+    assert macropy.core.unparse(kwargs["a"]) == "(1 + math.sqrt(5))", macropy.core.unparse(kwargs["a"])
+    assert list(map(macropy.core.unparse, args)) == ["((1 + 2) + 3)"], macropy.core.unparse(args)
+    return tree
+
+@macros.expr
 def expr_macro(tree, args, **kw):
     assert list(map(macropy.core.unparse, args)) == ["(1 + math.sqrt(5))"], macropy.core.unparse(args)
     return tree


### PR DESCRIPTION
My kwargs hack related to issue #13, mainly for discussion for now.

In this version:

- New magic is added to `**kw`, called `kwargs`.
- `kwargs` gets the AST, as a `list` of `ast.keyword` objects, of named arguments passed to the macro invocation.
- As a result of this change, full expr-macro invocation syntax (from normal run-time code) is now `mac(a0, ..., an, k0=v0, ..., km=vm)[body]`; the `kj=vj` pairs are new. Similarly for block and decorator macros (just the placement of `body` differs).

The named args are kept completely separate from the MacroPy `**kw` arguments, to protect MacroPy internals, and to prevent shadowing (in either direction). This captures only the user-given named args (e.g. `x=1`) in kwargs.

This complete separation is very important for the use of kwargs as syntax for binding constructs. Otherwise, e.g. a `let` construct might try to bind the name `gen_sym` (similarly for other MacroPy internals) because it happens to have an entry in `**kw`.

IMHO, the already existing args and the proposed kwargs together form one complete feature, namely the use of all the possibilities offered by Python's function call syntax, to provide extra slots for ASTs to be fed into the macro invocation beside the single body.

Also IMHO, this fixes an asymmetry in the MacroPy API. Already, macros can be given positional args, but no named args *from the use site*. (The existing implementation silently ignores named args, which I think is just an oversight; it should at least raise an error if we don't want to support named args. But that's really a separate issue.)

The body can of course already be a tuple, or really anything, so the whole feature does not add any fundamental capability - but it provides some flexibility for the syntax macros can offer to the user. For example, let constructs look more readable with a syntactically separate bindings block, which naturally takes one of the forms `let((x, 1), (y, 2))[body]` or `let(x=1, y=2)[body]`. I think the latter is more pythonic.

Thoughts?