### PR TITLE
Fix error logger crash

### DIFF
--- a/macropy/core/failure.py
+++ b/macropy/core/failure.py
@@ -24,7 +24,7 @@ def clear_errors(tree, **kw):
         tb = "".join(traceback.format_tb(tree.__traceback__))
         msg = str(tree)
         if type(tree) is not AssertionError or tree.args == ():
-            msg = ("".join(tree.args) + "\nCaused by Macro-Expansion Error:\n" +
+            msg = ("".join(str(x) for x in tree.args) + "\nCaused by Macro-Expansion Error:\n" +
                    tb)
         return hq[raise_error(MacroExpansionError(msg))]
     else:


### PR DESCRIPTION
Avoid crashing in error logger when the message of a macro expansion failure is not a string.

This happens more often than one would think, when developing new macros :)
