### PR TITLE
Live-reload macro definitions in console

### DIFF
--- a/macropy/core/console.py
+++ b/macropy/core/console.py
@@ -4,7 +4,6 @@
 import ast
 import code
 import importlib
-import sys
 from collections import OrderedDict
 
 from .macros import ModuleExpansionContext, detect_macros


### PR DESCRIPTION
This allows the REPL session to use the most up-to-date definitions of macros (from disk) whenever parsing the user input.

While at it, I also removed an unused import.

(This is for the basic Python+MacroPy console included with MacroPy, independent of the IPython REPL in #20.)